### PR TITLE
Add default avatar selection to profiles

### DIFF
--- a/public/avatars/defaults/avatar-01.svg
+++ b/public/avatars/defaults/avatar-01.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6366F1"/>
+      <stop offset="100%" stop-color="#22D3EE"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#g1)"/>
+  <g fill="#ffffff" opacity="0.95">
+    <circle cx="64" cy="52" r="22"/>
+    <path d="M20 110c8-20 26-32 44-32s36 12 44 32v2H20z"/>
+  </g>
+</svg>

--- a/public/avatars/defaults/avatar-02.svg
+++ b/public/avatars/defaults/avatar-02.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g2" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#F59E0B"/>
+      <stop offset="100%" stop-color="#EF4444"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#g2)"/>
+  <g fill="#ffffff" opacity="0.95">
+    <circle cx="64" cy="48" r="20"/>
+    <path d="M18 110c10-18 28-28 46-28s36 10 46 28v2H18z"/>
+  </g>
+</svg>

--- a/public/avatars/defaults/avatar-03.svg
+++ b/public/avatars/defaults/avatar-03.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g3" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#10B981"/>
+      <stop offset="100%" stop-color="#06B6D4"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#g3)"/>
+  <g fill="#ffffff" opacity="0.95">
+    <circle cx="64" cy="50" r="21"/>
+    <path d="M16 108c11-17 29-27 48-27s37 10 48 27v4H16z"/>
+  </g>
+</svg>

--- a/public/avatars/defaults/avatar-04.svg
+++ b/public/avatars/defaults/avatar-04.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g4" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#A78BFA"/>
+      <stop offset="100%" stop-color="#F472B6"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#g4)"/>
+  <g fill="#ffffff" opacity="0.95">
+    <circle cx="64" cy="52" r="22"/>
+    <path d="M14 110c12-20 31-32 50-32s38 12 50 32v2H14z"/>
+  </g>
+</svg>

--- a/public/avatars/defaults/avatar-05.svg
+++ b/public/avatars/defaults/avatar-05.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g5" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#34D399"/>
+      <stop offset="100%" stop-color="#60A5FA"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#g5)"/>
+  <g fill="#ffffff" opacity="0.95">
+    <circle cx="64" cy="50" r="20"/>
+    <path d="M18 108c10-18 28-28 46-28s36 10 46 28v4H18z"/>
+  </g>
+</svg>

--- a/public/avatars/defaults/avatar-06.svg
+++ b/public/avatars/defaults/avatar-06.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g6" x1="1" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#F43F5E"/>
+      <stop offset="100%" stop-color="#FB923C"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#g6)"/>
+  <g fill="#ffffff" opacity="0.95">
+    <circle cx="64" cy="48" r="19"/>
+    <path d="M16 108c11-17 29-27 48-27s37 10 48 27v4H16z"/>
+  </g>
+</svg>

--- a/public/avatars/defaults/avatar-07.svg
+++ b/public/avatars/defaults/avatar-07.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g7" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#06B6D4"/>
+      <stop offset="100%" stop-color="#9333EA"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#g7)"/>
+  <g fill="#ffffff" opacity="0.95">
+    <circle cx="64" cy="52" r="21"/>
+    <path d="M14 110c12-20 31-32 50-32s38 12 50 32v2H14z"/>
+  </g>
+</svg>

--- a/public/avatars/defaults/avatar-08.svg
+++ b/public/avatars/defaults/avatar-08.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g8" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0EA5E9"/>
+      <stop offset="100%" stop-color="#84CC16"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#g8)"/>
+  <g fill="#ffffff" opacity="0.95">
+    <circle cx="64" cy="50" r="20"/>
+    <path d="M18 110c10-18 28-28 46-28s36 10 46 28v0H18z"/>
+  </g>
+</svg>

--- a/public/avatars/defaults/avatar-09.svg
+++ b/public/avatars/defaults/avatar-09.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g9" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#22C55E"/>
+      <stop offset="100%" stop-color="#3B82F6"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#g9)"/>
+  <g fill="#ffffff" opacity="0.95">
+    <circle cx="64" cy="48" r="19"/>
+    <path d="M16 108c11-17 29-27 48-27s37 10 48 27v4H16z"/>
+  </g>
+</svg>

--- a/public/avatars/defaults/avatar-10.svg
+++ b/public/avatars/defaults/avatar-10.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g10" x1="1" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#F97316"/>
+      <stop offset="100%" stop-color="#06B6D4"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#g10)"/>
+  <g fill="#ffffff" opacity="0.95">
+    <circle cx="64" cy="52" r="21"/>
+    <path d="M14 110c12-20 31-32 50-32s38 12 50 32v2H14z"/>
+  </g>
+</svg>

--- a/src/config/defaultAvatars.ts
+++ b/src/config/defaultAvatars.ts
@@ -1,0 +1,17 @@
+export const DEFAULT_AVATARS: string[] = [
+  '/avatars/defaults/avatar-01.svg',
+  '/avatars/defaults/avatar-02.svg',
+  '/avatars/defaults/avatar-03.svg',
+  '/avatars/defaults/avatar-04.svg',
+  '/avatars/defaults/avatar-05.svg',
+  '/avatars/defaults/avatar-06.svg',
+  '/avatars/defaults/avatar-07.svg',
+  '/avatars/defaults/avatar-08.svg',
+  '/avatars/defaults/avatar-09.svg',
+  '/avatars/defaults/avatar-10.svg',
+];
+
+export function isDefaultAvatar(url: string | null | undefined): boolean {
+  if (!url) return false;
+  return DEFAULT_AVATARS.some((path) => url.endsWith(path));
+}

--- a/src/utils/profileService.ts
+++ b/src/utils/profileService.ts
@@ -107,19 +107,20 @@ export class ProfileService {
 
   static async deleteAvatar(userId: string, currentAvatarUrl: string): Promise<{ success: boolean; error?: string }> {
     try {
-      // Extract file path from URL if it's a Supabase storage URL
-      if (currentAvatarUrl && currentAvatarUrl.includes('avatars/')) {
-        const urlParts = currentAvatarUrl.split('/');
-        const fileName = urlParts[urlParts.length - 1];
-        const filePath = fileName; // Don't include 'avatars/' prefix since we're already in the avatars bucket
+      // Only delete from Supabase storage if the URL points to the public avatars bucket
+      const storagePathMarker = '/storage/v1/object/public/avatars/';
+      if (currentAvatarUrl && currentAvatarUrl.startsWith('http') && currentAvatarUrl.includes(storagePathMarker)) {
+        const filePath = currentAvatarUrl.substring(currentAvatarUrl.indexOf(storagePathMarker) + storagePathMarker.length);
 
-        // Delete from storage
-        const { error: deleteError } = await supabase.storage
-          .from('avatars')
-          .remove([filePath]);
+        if (filePath && !filePath.includes('/')) {
+          // Delete from storage
+          const { error: deleteError } = await supabase.storage
+            .from('avatars')
+            .remove([filePath]);
 
-        if (deleteError) {
-          console.error('Error deleting avatar file:', deleteError);
+          if (deleteError) {
+            console.error('Error deleting avatar file:', deleteError);
+          }
         }
       }
 


### PR DESCRIPTION
Add a default avatar selection feature to the profile page to allow users to choose from a set of pre-defined avatars.

The avatar deletion logic was updated to prevent accidental removal of default avatars from Supabase storage, ensuring only user-uploaded avatars are deleted.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b534ba2-136c-4fe7-9390-5dfdac080904">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9b534ba2-136c-4fe7-9390-5dfdac080904">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

