### PR TITLE
Fix broken avatar display

### DIFF
--- a/src/config/defaultAvatars.ts
+++ b/src/config/defaultAvatars.ts
@@ -1,17 +1,25 @@
-export const DEFAULT_AVATARS: string[] = [
-  '/avatars/defaults/avatar-01.svg',
-  '/avatars/defaults/avatar-02.svg',
-  '/avatars/defaults/avatar-03.svg',
-  '/avatars/defaults/avatar-04.svg',
-  '/avatars/defaults/avatar-05.svg',
-  '/avatars/defaults/avatar-06.svg',
-  '/avatars/defaults/avatar-07.svg',
-  '/avatars/defaults/avatar-08.svg',
-  '/avatars/defaults/avatar-09.svg',
-  '/avatars/defaults/avatar-10.svg',
+// Prefix public asset paths with the app base so they work under subpaths (e.g. GitHub Pages, PWA scope)
+const BASE_URL: string = (import.meta as any).env?.BASE_URL || '/';
+
+const DEFAULT_AVATAR_FILENAMES: string[] = [
+  'avatar-01.svg',
+  'avatar-02.svg',
+  'avatar-03.svg',
+  'avatar-04.svg',
+  'avatar-05.svg',
+  'avatar-06.svg',
+  'avatar-07.svg',
+  'avatar-08.svg',
+  'avatar-09.svg',
+  'avatar-10.svg',
 ];
+
+export const DEFAULT_AVATARS: string[] = DEFAULT_AVATAR_FILENAMES.map(
+  (name) => `${BASE_URL}avatars/defaults/${name}`
+);
 
 export function isDefaultAvatar(url: string | null | undefined): boolean {
   if (!url) return false;
-  return DEFAULT_AVATARS.some((path) => url.endsWith(path));
+  // Check by filename so it works regardless of base URL or absolute origin
+  return DEFAULT_AVATAR_FILENAMES.some((name) => url.endsWith(name));
 }


### PR DESCRIPTION
Prefix default avatar URLs with the app's base path and update default avatar detection to fix broken images in subpath deployments.

---
<a href="https://cursor.com/background-agent?bcId=bc-294c9aef-4e75-4b39-b2f7-f69f526fb127">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-294c9aef-4e75-4b39-b2f7-f69f526fb127">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

