### PR TITLE
Add youtube video previews to search and watchlist

### DIFF
--- a/src/pages/Watched.tsx
+++ b/src/pages/Watched.tsx
@@ -158,7 +158,7 @@ export default function Watched() {
 
                     {/* Streaming Sources / YouTube Link */}
                     <div className="space-y-3">
-                      {item.type === 'youtube' ? (
+                      {item.type === 'youtube' || (item as any).youtube_url ? (
                         <>
                           <h4 className="font-semibold text-sm">Watch on YouTube:</h4>
                           <Button

--- a/src/pages/Watchlist.tsx
+++ b/src/pages/Watchlist.tsx
@@ -158,7 +158,7 @@ export default function Watchlist() {
 
                     {/* Streaming Sources / YouTube Link */}
                     <div className="hidden sm:block space-y-3">
-                      {item.type === 'youtube' ? (
+                      {item.type === 'youtube' || (item as any).youtube_url ? (
                         <>
                           <h4 className="font-semibold text-sm">Watch on YouTube:</h4>
                           <Button

--- a/src/utils/watchlistService.ts
+++ b/src/utils/watchlistService.ts
@@ -44,10 +44,9 @@ export class WatchlistService {
         confidence: content.confidence,
         user_id: user.id,
         watched: false,
-        ...(content.type === 'youtube' && {
-          youtube_url: content.youtubeUrl,
-          channel_name: content.channelName
-        })
+        // Persist YouTube preview info when available (for all types)
+        youtube_url: content.youtubeUrl || null,
+        channel_name: content.channelName || null
       };
 
       const { data, error } = await supabase

--- a/supabase/functions/analyze-image/index.ts
+++ b/supabase/functions/analyze-image/index.ts
@@ -702,6 +702,24 @@ serve(async (req) => {
         console.log(`✅ Content processing complete - ${streamingSources.length} streaming sources found`);
         console.groupEnd();
         
+        // Best-effort: also try to fetch a YouTube trailer for preview embedding
+        try {
+          const trailerQuery = `${item.title} ${item.year || ''} official trailer`.trim();
+          const trailerData = await fetchYouTubeData(trailerQuery);
+          if (trailerData?.url) {
+            return {
+              ...item,
+              poster,
+              streamingSources,
+              releaseDate: `${item.year}`,
+              youtubeUrl: trailerData.url,
+              channelName: trailerData.channelName
+            };
+          }
+        } catch (ytErr) {
+          console.log(`⚠️  Trailer fetch failed for ${item.title}: ${ytErr instanceof Error ? ytErr.message : String(ytErr)}`);
+        }
+
         return {
           ...item,
           poster,


### PR DESCRIPTION
Embed YouTube trailers on search results and link to previews on watchlist cards to enhance media discovery.

---
<a href="https://cursor.com/background-agent?bcId=bc-4367a8ae-c72e-4bf4-8bd7-ef565299e685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4367a8ae-c72e-4bf4-8bd7-ef565299e685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

