### PR TITLE
fix: Make search result images full-width on mobile devices

### DIFF
--- a/src/components/ResultsDisplay.tsx
+++ b/src/components/ResultsDisplay.tsx
@@ -159,9 +159,9 @@ export const ResultsDisplay = ({ results, onNewSearch }: ResultsDisplayProps) =>
       <div className="grid gap-4 md:gap-6">
         {sortedResults.map((content, index) => (
           <Card key={index} className="result-card overflow-hidden">
-            <div className="flex gap-4">
+            <div className="flex flex-col md:flex-row gap-4">
               {/* Poster Image */}
-              <div className={`flex-shrink-0 ${content.type === 'youtube' ? 'w-32 sm:w-48 aspect-video' : 'w-24 sm:w-32 aspect-[2/3]'}`}>
+              <div className={`flex-shrink-0 ${content.type === 'youtube' ? 'w-full md:w-48 aspect-video' : 'w-full md:w-32 aspect-[2/3]'}`}>
                 <img
                   src={content.poster}
                   alt={content.title}


### PR DESCRIPTION
- Changed layout from fixed horizontal to responsive flex layout
- Images now take full width on mobile (w-full) for better visibility
- Maintains horizontal layout with fixed image widths on desktop (md:w-32, md:w-48)
- Updated flex direction: flex-col on mobile, md:flex-row on desktop

Fixes #16

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves mobile layout of result cards for better responsiveness.
> 
> - Changes card layout to `flex-col` on mobile and `md:flex-row` on desktop
> - Makes poster image `w-full` on mobile with `md:w-48` (YouTube) or `md:w-32` (others) while preserving aspect ratios
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 734a23fb69f08f48f0aa64b085a3cd6444eede9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->