### PR TITLE
Visual stream finder issue

### DIFF
--- a/src/components/MediaCard.tsx
+++ b/src/components/MediaCard.tsx
@@ -2,7 +2,6 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Star, Clock, Calendar, Trash2, RotateCcw, Eye } from 'lucide-react';
-import { StreamingIcon } from '@/components/StreamingIcon';
 
 const typeColors: Record<string, string> = {
   movie: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
@@ -48,14 +47,6 @@ export function MediaCard({
   onRemove,
   variant = 'watchlist',
 }: MediaCardProps) {
-  // Group streaming sources
-  const groupedSources = item.streaming_sources?.reduce((acc: any, source: any) => {
-    if (!acc[source.name]) {
-      acc[source.name] = { name: source.name, url: source.url };
-    }
-    return acc;
-  }, {}) || {};
-
   return (
     <Card className="overflow-hidden w-full shadow-lg hover:shadow-xl transition-shadow duration-200">
       {/* Mobile: Horizontal card - tap to open details */}
@@ -154,29 +145,6 @@ export function MediaCard({
                 )}
               </div>
             </div>
-
-            {/* Streaming sources - compact icons */}
-            {item.streaming_sources && item.streaming_sources.length > 0 && (
-              <div className="flex gap-1.5 flex-wrap">
-                {Object.values(groupedSources).slice(0, 4).map((service: any, index: number) => (
-                  <button
-                    key={index}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      window.open(service.url, '_blank');
-                    }}
-                    className="p-1.5 rounded-md bg-secondary/50 hover:bg-secondary transition-colors"
-                    title={service.name}
-                  >
-                    <StreamingIcon
-                      serviceId={service.name.toLowerCase().replace(/[^a-z0-9]/g, '')}
-                      serviceName={service.name}
-                      className="w-4 h-4"
-                    />
-                  </button>
-                ))}
-              </div>
-            )}
 
             {/* Action buttons */}
             <div className="flex gap-1.5 pt-1">


### PR DESCRIPTION
Remove streaming service icons from `MediaCard` components to address issue #14, ensuring they only appear in the detail sheet.

---
<a href="https://cursor.com/background-agent?bcId=bc-da802538-5a90-4db4-a829-8583d515d8e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-da802538-5a90-4db4-a829-8583d515d8e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes streaming service icons from `MediaCard` list/grid cards to limit them to the detail view.
> 
> - Deletes `StreamingIcon` import and the `groupedSources` aggregation logic
> - Removes the streaming sources icon/button section from both mobile and desktop card render paths
> - No changes to actions (`Fav`, `Seen`, `Unsee`, `Remove`) or displayed metadata (title, year, rating, runtime)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45bc3be7d546028c1260ed56e12b441053127e8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->